### PR TITLE
Easy Inclusion File, mirroring model_utils/layers.py and model_utils/losses.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,26 +15,45 @@ Echo noise is flexible, data-driven alternative to Gaussian noise that admits an
 
 ## Echo Noise
 
-For easy inclusion in other projects, the Echo Noise functions are included
+For easy inclusion in other projects, the echo noise functions are included
 in one all-in-one file, ```echo_noise.py```, which can be copied to a project
 and included directly, e.g.:
 ```python
 import echo_noise
 ```
 
-These functions are also found in the experiments code,
- ```model_utils/layers.py``` and ```model_utils/losses.py```.
-
-Echo is implemented using a similar setup to VAEs.
-The following illustrates the usage of the noise function (```echo_sample```)
+There are two basic functions
+implemented, the noise function itself (```echo_sample```)
 and the MI calculation (```echo_loss```), both of which are included in
-```echo_noise.py```:
+```echo_noise.py```. Except for libaries, ```echo_noise.py``` has no other
+file dependencies.
+
+Echo noise is meant to be used similarly to the Gaussian noise in VAEs, and
+was implemented with VAE implementations in mind. Assuming the decoder
+provides ```z_mean``` and ```z_log_scale```, a Gaussian Encoder would look
+something like:
+```python
+z = z_mean + tf.exp(z_log_scale) * tf.random.normal( tf.shape(z_mean) )
+```
+The Echo noise equivalent implemented here is:
+```python
+z = echo_noise.echo_sample( [z_mean, z_log_scale] )
+```
+Similarly, VAEs often calculate a KL divergence penalty based on
+```z_mean``` and ```z_log_scale```. The Echo noise penalty can be computed
+using:
+```python
+echo_noise.echo_loss([z_log_scale])
+```
+A Keras version of this might look like the following:
 ```python
 z_mean = Dense(latent_dim, activation = model_utils.activations.tanh64)(h)
 z_log_scale = Dense(latent_dim, activation = tf.math.log_sigmoid)(h)
-z_activation = Lambda(ech.echo_sample)([z_mean, z_log_scale])
-echo_loss = Lambda(model_utils.losses.echo_loss)([z_log_scale])
+z_activation = Lambda(echo_noise.echo_sample)([z_mean, z_log_scale])
+echo_loss = Lambda(echo_noise.echo_loss)([z_log_scale])
 ```
+
+These functions are also found in the experiments code, ```model_utils/layers.py``` and ```model_utils/losses.py```.
 
 We can choose to sample training examples with or without replacement from within the batch for constructing Echo noise.  A quirk of the current implementation is that sampling with replacement sets the batch dimension != None. This means the model cannot accommodate different batch sizes (e.g. if ```data.shape[0] % batch > 0```) and should be trained using, e.g. ```fit_generator```.   Sampling without replacement does not have this issue.
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,27 @@ Echo noise is flexible, data-driven alternative to Gaussian noise that admits an
 
 ## Echo Noise
 
-Echo is implemented using a similar setup to VAEs.  You can use the Echo functions in ```layers.py``` and ```losses.py``` as follows: 
+For easy inclusion in other projects, the Echo Noise functions are included
+in one all-in-one file, ```echo_noise.py```, which can be copied to a project
+and included directly, e.g.:
+```python
+import echo_noise
 ```
+
+These functions are also found in the experiments code,
+ ```model_utils/layers.py``` and ```model_utils/losses.py```.
+
+Echo is implemented using a similar setup to VAEs.
+The following illustrates the usage of the noise function (```echo_sample```)
+and the MI calculation (```echo_loss```), both of which are included in
+```echo_noise.py```:
+```python
 z_mean = Dense(latent_dim, activation = model_utils.activations.tanh64)(h)
 z_log_scale = Dense(latent_dim, activation = tf.math.log_sigmoid)(h)
-z_activation = Lambda(model_utils.layers.echo_sample)([z_mean, z_log_scale])
+z_activation = Lambda(ech.echo_sample)([z_mean, z_log_scale])
 echo_loss = Lambda(model_utils.losses.echo_loss)([z_log_scale])
 ```
+
 We can choose to sample training examples with or without replacement from within the batch for constructing Echo noise.  A quirk of the current implementation is that sampling with replacement sets the batch dimension != None. This means the model cannot accommodate different batch sizes (e.g. if ```data.shape[0] % batch > 0```) and should be trained using, e.g. ```fit_generator```.   Sampling without replacement does not have this issue.
 
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ The Echo noise equivalent implemented here is:
 z = echo_noise.echo_sample( [z_mean, z_log_scale] )
 ```
 Similarly, VAEs often calculate a KL divergence penalty based on
-```z_mean``` and ```z_log_scale```. The Echo noise penalty can be computed
+```z_mean``` and ```z_log_scale```. The Echo noise penalty, which is the
+mutual information `I(x,z)`, can be computed
 using:
 ```python
-echo_noise.echo_loss([z_log_scale])
+loss = ... + echo_noise.echo_loss([z_log_scale])
 ```
 A Keras version of this might look like the following:
 ```python

--- a/echo_noise.py
+++ b/echo_noise.py
@@ -1,0 +1,215 @@
+
+import keras.backend as K
+import numpy as np
+import tensorflow as tf 
+
+#
+# helper funcs
+#
+
+# sampling with replacement, without setting batch dimension
+def random_indices(n, d):
+    return tf.random.uniform((n * d,), minval=0, maxval=n, dtype=tf.int32)
+
+def gather_nd_reshape(t, indices, final_shape):
+    h = tf.gather_nd(t, indices)
+    return K.reshape(h, final_shape)
+
+#
+# Produce an index tensor that gives a permuted matrix of other samples in
+# batch, per sample.
+#
+# Parameters
+# ----------
+# batch_size : int
+#     Number of samples in the batch.
+# d_max : int
+#     The number of blocks, or the number of samples to generate per sample.
+#
+# Deps:
+#   numpy
+def permute_neighbor_indices(
+    batch_size,
+    d_max=-1, replace = False, pop = True,
+    ):
+
+    if d_max < 0:
+        d_max = batch_size + d_max
+
+    inds = []
+    if not replace:
+        for i in range(batch_size):
+            sub_batch = list(range(batch_size))
+
+            # pop = False includes training sample for echo 
+            # (i.e. dmax = batch instead of dmax = batch - 1)
+            if pop:
+                sub_batch.pop(i)
+            np.random.shuffle(sub_batch)
+            inds.append(list(enumerate(sub_batch[:d_max])))
+        return inds
+
+    else:
+        for i in range(batch_size):
+            inds.append( list( enumerate(
+                np.random.choice(batch_size, size = d_max, replace = True)
+            )))
+        return inds
+
+#
+# This function implements the Echo Noise distribution specified in:
+#   Exact Rate-Distortion in Autoencoders via Echo Noise
+#   Brekelmans et al. 2019
+#   https://arxiv.org/abs/1904.07199
+#
+# Parameters
+# ----------
+# inputs should be specified as list:
+#   [ f(X), s(X) ] with s(X) in log space if calc_log = True 
+# the flag plus_sx should be:
+#   True if logsigmoid activation for s(X)
+#   False for softplus (equivalent)
+#
+# Deps:
+#   numpy
+#   tensorflow
+#   permute_neighbor_indices (above)
+#   gather_nd_reshape (above)
+#   random_indices (above)
+def echo_sample(
+    inputs,
+    clip=None, d_max=100, batch=100, multiplicative=False, echo_mc = False,
+    replace=False, fx_clip=None, plus_sx=True, calc_log=True,
+    return_noise=False, **kwargs
+    ):
+    # kwargs unused
+
+    if isinstance(inputs, list):
+        fx = inputs[0]
+        sx = inputs[-1]
+    else:
+        fx = inputs
+
+    # TO DO : CALC_LOG currently determines both whether to do log space calculations AND whether sx is a log
+ 
+    fx_shape = fx.get_shape()
+    sx_shape = sx.get_shape()
+
+
+    # clip is multiplied times s(x) to ensure that last sampled term:
+    #   (clip^d_max)*f(x) < machine precision 
+    if clip is None:
+        max_fx = fx_clip if fx_clip is not None else 1.0
+        clip = (2**(-23)/max_fx)**(1.0/d_max)
+    
+    # fx_clip can be used to restrict magnitude of f(x), not used in paper
+    # defaults to no clipping and M = 1 (e.g. with tanh activation for f(x))
+    if fx_clip is not None: 
+        fx = K.clip(fx, -fx_clip, fx_clip)
+
+    if not calc_log:
+        sx = tf.multiply(clip,sx)
+        sx = tf.where(tf.abs(sx) < K.epsilon(), K.epsilon()*tf.sign(sx), sx)
+    else:
+        # plus_sx based on activation for sx = s(x):
+        #   True for log_sigmoid
+        #   False for softplus
+        sx = tf.log(clip) + (-1*sx if not plus_sx else sx)
+
+    if echo_mc is not None:    
+        # use mean centered fx for noise
+        fx = fx - K.mean(fx, axis = 0, keepdims = True)
+
+    z_dim = K.int_shape(fx)[-1]
+
+    if replace: # replace doesn't set batch size (using permute_neighbor_indices does)
+        batch = K.shape(fx)[0]
+        sx = K.batch_flatten(sx) if len(sx_shape) > 2 else sx 
+        fx = K.batch_flatten(fx) if len(fx_shape) > 2 else fx 
+        inds = K.reshape(random_indices(batch, d_max), (-1, 1))
+        select_sx = gather_nd_reshape(sx, inds, (-1, d_max, z_dim))
+        select_fx = gather_nd_reshape(fx, inds, (-1, d_max, z_dim))
+
+        if len(sx_shape)>2:
+            select_sx = K.expand_dims(K.expand_dims(select_sx, 2), 2)
+            sx = K.expand_dims(K.expand_dims(sx, 1),1)
+        if len(fx_shape)>2:
+            select_fx = K.expand_dims(K.expand_dims(select_fx, 2), 2)
+            fx = K.expand_dims(K.expand_dims(fx, 1),1)
+
+    else:
+        # batch x batch x z_dim 
+        # for all i, stack_sx[i, :, :] = sx
+        repeat = tf.multiply(tf.ones_like(tf.expand_dims(fx, 0)), tf.ones_like(tf.expand_dims(fx, 1)))
+        stack_fx = tf.multiply(fx, repeat)
+        stack_sx = tf.multiply(sx, repeat)
+
+        # select a set of dmax examples from original fx / sx for each batch entry
+        inds = permute_neighbor_indices(batch, d_max, replace = replace)
+        
+        # note that permute_neighbor_indices sets the batch_size dimension != None
+        # this necessitates the use of fit_generator, e.g. in training to avoid 'remainder' batches if data_size % batch > 0
+        
+        select_sx = tf.gather_nd(stack_sx, inds)
+        select_fx = tf.gather_nd(stack_fx, inds)
+
+    if calc_log:
+        sx_echoes = tf.cumsum(select_sx, axis = 1, exclusive = True)
+    else:
+        sx_echoes = tf.cumprod(select_sx, axis = 1, exclusive = True)
+
+    # calculates S(x0)S(x1)...S(x_l)*f(x_(l+1))
+    sx_echoes = tf.exp(sx_echoes) if calc_log else sx_echoes 
+    fx_sx_echoes = tf.multiply(select_fx, sx_echoes) 
+
+    # performs the sum over dmax terms to calculate noise
+    noise = tf.reduce_sum(fx_sx_echoes, axis = 1) 
+
+    if multiplicative:
+        # unused in paper, not extensively tested  
+      sx = sx if not calc_log else tf.exp(sx)
+      output = tf.exp(fx + tf.multiply(sx, noise))#tf.multiply(fx, tf.multiply(sx, noise))
+    else:
+      sx = sx if not calc_log else tf.exp(sx)
+      output = fx + tf.multiply(sx, noise)
+    
+    sx = sx if not calc_log else tf.exp(sx) 
+    
+    if multiplicative: # log z according to echo
+        output = tf.exp(fx + tf.multiply(sx, noise))
+    else:
+        output = fx + tf.multiply(sx, noise) 
+
+    return output if not return_noise else noise
+
+#
+# This function implements the Mutual Information penalty (via Echo Noise)
+# which was specified in:
+#
+#   Exact Rate-Distortion in Autoencoders via Echo Noise
+#   Brekelmans et al. 2019
+#   https://arxiv.org/abs/1904.07199
+#
+# Parameters
+# ----------
+# inputs: tensor
+#   The sigmoid outputs from an encoder (don't include the mean outputs).
+#
+# TODO: Rob, please explain where the clip number comes from. (DM)
+#
+def echo_loss(inputs,
+    clip= 0.8359, calc_log = True, plus_sx = True, multiplicative = False,
+    **kwargs):
+    if isinstance(inputs, list):
+        z_mean = inputs[0]
+        z_scale = inputs[-1]
+    else:
+        z_scale = inputs
+
+    # calc_log indicates whether z_scale is already in log terms
+
+    mi = -K.log(K.abs(clip*z_scale)+K.epsilon()) if not calc_log else -(tf.log(clip) + (z_scale if plus_sx else -z_scale))
+    
+    return mi
+
+


### PR DESCRIPTION
Hey! So I split off the really important bits of Echo into one file so people could easily use it as a drag-and-drop replacement for Gaussian Noise.

It's basically a clone of the relevant lines from `model_utils/layers.py` and `model_utils/losses.py`.

It also doesn't require TFP anymore, at least for including _just_ echo.

If you do choose to include this, at a later date we should probably collapse all the implementations to just the one file (so that changes will propagate between the two). Sorry for splitting implementations, but I thought it'd be easier for people to just grab and use (and cite) this way.

Thanks!
Dan